### PR TITLE
Add Laravel 6 as an accepted version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5"
+        "illuminate/support": "~5 || ~6"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"


### PR DESCRIPTION
There weren't any changes on service providers, used by this library, in Laravel 6. Therefore, this library is still valid for Laravel 6